### PR TITLE
Fix expectation in AppComponent unit test to use a Promise

### DIFF
--- a/e2e/src/app.e2e-spec.ts
+++ b/e2e/src/app.e2e-spec.ts
@@ -14,6 +14,7 @@ describe('Sarah Oak website', () => {
     await expect(
       element(by.css('oak-app *'))
         .getWebElement()
+        .then()
     )
       .toBeTruthy();
   });


### PR DESCRIPTION
Jasmine refuses to use the WebElementPromise returned by getWebElement